### PR TITLE
Fix warning from build action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,13 +11,13 @@ runs:
   using: "composite"
   steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.11.0
+        uses: styfle/cancel-workflow-action@0.12.1
 
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version }}
 


### PR DESCRIPTION
When this GH Action is executed you get a warning:

```
build
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: styfle/cancel-workflow-action@0.11.0, actions/checkout@v3, actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

The changes in this PR update the actions to use node 20.